### PR TITLE
fix asymmetric parentheses error in ex2

### DIFF
--- a/mlclass-ex2/costFunctionReg.m
+++ b/mlclass-ex2/costFunctionReg.m
@@ -21,18 +21,18 @@ grad = zeros(size(theta));
 z=X*theta;
 h=sigmoid(z);
 logisf=(-y)'*log(h)-(1-y)'*log(1-h);
-
+Xtran = X';
 J=((1/m).*sum(logisf))+(lambda/(2*m)).*sum(theta.^2);
 
 k=length(theta)-1;
 n=length(theta);
-%grad(1)=1/m.*(X'(1)*h-X'(1)*y(1));
-grad(1)=1/m.*(sum(X'(1,:)*h-X'(1,:)*y));
-%grad(1)=1/m.*(X'*h-X'*y);
-%grad=(1/m).*((X'*h-X'*y)+theta*lambda);  % This gives correct answer but ...
+%grad(1)=1/m.*(Xtran(1)*h-Xtran(1)*y(1));
+grad(1)=1/m.*(sum(Xtran(1,:)*h-Xtran(1,:)*y));
+%grad(1)=1/m.*(Xtran*h-Xtran*y);
+%grad=(1/m).*((Xtran*h-Xtran*y)+theta*lambda);  % This gives correct answer but ...
 
 for j=2:n
-	grad(j)=(1/m).*(sum(X'(j,:)*h-X'(j,:)*y)+lambda.*theta(j,1));
+	grad(j)=(1/m).*(sum(Xtran(j,:)*h-Xtran(j,:)*y)+lambda.*theta(j,1));
 end
 
 % =============================================================


### PR DESCRIPTION
My programming environment is Matlab 2014b and I find that it is necessary to  transpose matrix X before slicing,if not matlab will prompt
error and script stop running.
Although I know this repo has already been out of maintenance,these changes works. :)