### PR TITLE
Missing subtraction of theta(0)

### DIFF
--- a/mlclass-ex2/costFunctionReg.m
+++ b/mlclass-ex2/costFunctionReg.m
@@ -23,6 +23,7 @@ h=sigmoid(z);
 logisf=(-y)'*log(h)-(1-y)'*log(1-h);
 
 J=((1/m).*sum(logisf))+(lambda/(2*m)).*sum(theta.^2);
+J -= lambda/(2*m) * theta(1)^2;
 
 k=length(theta)-1;
 n=length(theta);


### PR DESCRIPTION
In Octave/MAT-LAB, recall that indexing starts from 1, hence, you should not be regularizing
the theta(1) parameter (which corresponds to theta(0)) in the code.

added the subtraction of the first value of theta at line 26